### PR TITLE
Fix test on older Quadro P1000.

### DIFF
--- a/tests/gpu.yaml
+++ b/tests/gpu.yaml
@@ -12,7 +12,7 @@ nvhpc:
     modules: ['nvhpc/21.11']
     source_path: vector_add.cu
     cmds:
-      - nvcc vector_add.cu -o vector_add
+      - nvcc -gencode=arch=compute_61,code=sm_61 vector_add.cu -o vector_add
   run:
     modules: ['nvhpc/21.11']
     cmds:


### PR DESCRIPTION
Testing NVHPC 21.11 on a Quadro P1000 with Driver Version: 470.129.06 and CUDA Version: 11.4 failed with the following error:

```
[Vector addition of 50000 elements]
Failed to allocate device vector A (error code the provided PTX was compiled with an unsupported toolchain.)!
```

This was fixed by adding in the `-gencode` switch to `nvcc` for the correct arch/compute capabilities when building the binary. [See here](https://docs.nvidia.com/cuda/ampere-compatibility-guide/index.html#building-applications-using-cuda-toolkit-11-0)

```
nvcc -gencode=arch=compute_61,code=sm_61
```

Once we have a newer gpu to test with we may need to tweak this.