### PR TITLE
Changed the git chckout to the ssh (ssh keys) URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ $ mkdir -p $HOME/testsuite/working_dir
 
 ```
 $ cd $HOME/testsuite
-$ git clone https://github.com/YOURUSER/sanitarium.git
+$ git clone git@github.com:YOURUSER/sanitarium.git
+$ git remote add upstream git@github.com:ubccr/sanitarium.git
 ```
 
 3. Check that everything works:


### PR DESCRIPTION
Password authentication for https:// github URLS has been removed as per:
    https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories#cloning-with-https-urls
"Password-based authentication for Git has been removed in favor of more secure authentication methods."

Added the remote upstream as well

Tony